### PR TITLE
bugfix: wrong path for getTransactionSizeForHDWallet request

### DIFF
--- a/src/common/blockchain/base-transaction.js
+++ b/src/common/blockchain/base-transaction.js
@@ -321,7 +321,7 @@ class BaseTransaction extends BaseChainComponent {
             outputs,
         };
 
-        return this.request.post(this.basePath + this.getSelectedNetwork() + '/wallets/hd/txs/size ', data, queryParams);
+        return this.request.post(this.basePath + this.getSelectedNetwork() + '/wallets/hd/txs/size', data, queryParams);
     }
 
 }


### PR DESCRIPTION
Space in the end of request path cause an error with code 41 'URI not found. Check the documentation."